### PR TITLE
Support recursive object traversal

### DIFF
--- a/src/Handlebars/Context.php
+++ b/src/Handlebars/Context.php
@@ -157,7 +157,9 @@ class Handlebars_Context
     private function _findVariableInContext($variable, $inside, $strict = false)
     {
         $value = '';
-        if (is_array($variable)) {
+        if ( empty( $inside ) || ( $inside == 'this' ) ) {
+            return $variable;
+        } elseif (is_array($variable)) {
             if (isset($variable[$inside])) {
                 $value = $variable[$inside];
             }


### PR DESCRIPTION
Nested this.property traversal wasn't possible. With this fix, it is.
