### PR TITLE
Support for context passed into a partial as an argument

### DIFF
--- a/src/Handlebars/Template.php
+++ b/src/Handlebars/Template.php
@@ -154,7 +154,7 @@ class Handlebars_Template
                 array_push($this->_stack, array(0, $newStack, false));
                 $buffer .= $this->_inverted($context, $current);
                 array_pop($this->_stack);
-                break;            
+                break;
             case Handlebars_Tokenizer::T_COMMENT :
                 $buffer .= '';
                 break;
@@ -297,7 +297,7 @@ class Handlebars_Template
             return '';
         }
     }
-    
+
     /**
      * Process partial section
      *
@@ -309,6 +309,11 @@ class Handlebars_Template
     private function _partial($context, $current)
     {
         $partial = $this->handlebars->loadPartial($current[Handlebars_Tokenizer::NAME]);
+
+        if ( $current[Handlebars_Tokenizer::ARGS] ) {
+            $context = $context->get($current[Handlebars_Tokenizer::ARGS]);
+        }
+
         return $partial->render($context);
     }
 

--- a/src/Handlebars/Tokenizer.php
+++ b/src/Handlebars/Tokenizer.php
@@ -157,7 +157,12 @@ class Handlebars_Tokenizer
             default:
                 if ($this->tagChange($this->ctag, $text, $i)) {
                     // Sections (Helpers) can accept parameters
-                    if ($this->tagType == self::T_SECTION) {
+                    // Same thing for Partials (little known fact)
+                    if (
+                        ($this->tagType == self::T_SECTION)
+                        || ($this->tagType == self::T_PARTIAL)
+                        || ($this->tagType == self::T_PARTIAL_2)
+                    ) {
                         $newBuffer = explode(' ', trim($this->buffer), 2);
                         $args = '';
                         if (count($newBuffer) == 2) {


### PR DESCRIPTION
I tried to look this up in the handlebars and mustache documentation, but it seems undocumented. Anyways, partials should be able to accept an argument that establishes a new context:

http://stackoverflow.com/questions/11523331/passing-variables-through-handlebars-partial
# Example

base.hbs:

```
{{> files files}}
```

files.hbs:

```
{{#each this}}
    <file>{{this}}</file>
{{/each}}
```

data:

```
{
    "files":[
        "file1.txt",
        "file2.txt"
    ]
}
```

Before my pull request, you would get an error that the template "files files" wasn't found. With the pull request, the template renders the property "files" as "this". The result looks like this:

```
<file>file1.txt</file>
<file>file2.txt</file>
```
