### PR TITLE
Added support for @index in #each-helper when used on lists.

### DIFF
--- a/src/Handlebars/Helpers.php
+++ b/src/Handlebars/Helpers.php
@@ -104,12 +104,22 @@ class Handlebars_Helpers
 		$tmp = $context->get($args);
 		$buffer = '';
 		if (is_array($tmp) || $tmp instanceof Traversable) {
+			$islist = ( array_keys($tmp) == range(0, count($tmp) - 1) );
+
 			foreach ($tmp as $key => $var) {
-				$context->pushKey($key);
+				if( $islist ) {
+					$context->pushIndex($key);
+				} else {
+					$context->pushKey($key);
+				}
 				$context->push($var);
 				$buffer .= $template->render($context);
 				$context->pop();
-				$context->popKey();
+				if( $islist ) {
+					$context->popIndex();
+				} else {
+					$context->popKey();
+				}
 			}
 		}
 		return $buffer;


### PR DESCRIPTION
You're welcome. Thanks for the quick merge!

I've now added support for @index when iterating over lists using `#each`. When you use `#each` on an object, you can use `@key` to access the key, and when you iterate over a list, you can use `@index` to get the index. Although it is a bit annoying to think about it when you are writing the template, it is consistent with the documentation and Handlebars.js.
