### PR TITLE
Allow each helper to accept PHP Generators

### DIFF
--- a/src/Handlebars/Helpers.php
+++ b/src/Handlebars/Helpers.php
@@ -117,7 +117,7 @@ class Helpers
                 $tmp = $context->get($args);
                 $buffer = '';
                 if (is_array($tmp) || $tmp instanceof \Traversable) {
-                    $islist = (array_keys($tmp) == range(0, count($tmp) - 1));
+                    $islist = ($tmp instanceof \Generator) || (array_keys($tmp) == range(0, count($tmp) - 1));
 
                     foreach ($tmp as $key => $var) {
                         if ($islist) {


### PR DESCRIPTION
Output from the following function:

``` php
function getItems() {

   //Some code

   while( $stream->more() ) {
      yield [ 'id' => $stream->id(), 'text' => $stream->text() ];
   }
}

```

Can now be directly fed as follows:

``` handlebars

{{#each items}}
   {{id}} - {{text}}
{{/each}}

```
