### PR TITLE
Update Context::get to resolve @key and @index

### DIFF
--- a/src/Handlebars/Context.php
+++ b/src/Handlebars/Context.php
@@ -226,7 +226,7 @@ class Context
         } elseif ($variableName == '@key') {
             $current = $this->lastKey();
         } elseif ($variableName[0] == "'" || $variableName[0] == '"') {
-            if ($variableName[0] == substr($variableName, -1) && strlen($variableName) > 2){
+            if ($variableName[0] == substr($variableName, -1) && strlen($variableName) > 2) {
                 $current = substr($variableName, 1, strlen($variableName) -2);
             } else {
                 throw new \RuntimeException("Malformed string: ".$variableName);

--- a/src/Handlebars/Template.php
+++ b/src/Handlebars/Template.php
@@ -424,11 +424,12 @@ class Template
     /**
      * Break an argument string into an array of strings
      *
-     * @param string  $string Argument String as passed to a helper
+     * @param string $string Argument String as passed to a helper
      *
      * @return array the argument list as an array
      */
-    public function parseArguments($string){
+    public function parseArguments($string)
+    {
         $parts = array();
         preg_match_all('#(?<!\\\\)("|\')(?:[^\\\\]|\\\\.)*?\1|\S+#s', $string, $parts);
         $parts =  isset($parts[0])?$parts[0]:array();


### PR DESCRIPTION
Change to allow @key and @index to be resolved within Context::get calls. 

For Example to port this javascript helper

```
Handlebars.registerHelper("ifEquals", function (name, value,options){
    if (name == value) {
        return options.fn(this)
    }; 
});
```

Helpers that could accept @key and @index as parameters previously had to implemented like 

```
$handleBars->addHelper("ifEquals", function ($template, $context, $args, $source){
    list($property, $value) = explode(" ", $args);
    if ($property == "@index"){
        $property = $context->lastIndex();
    } else if ($property == "@key") {
        $property = $context->lastKey();
    } else {
        $property = $context->get($value);     
    }
    if ($value == "@index"){
        $value = $context->lastIndex();
    } else if ($property == "@key") {
        $value = $context->lastKey();
    } else {
        $value = $context->get($value);     
    }
    if ($property == $value){
        return $template->render($context);
    }       
});
```

Can Now be implemented as 

```
$handleBars->addHelper("ifEquals", function ($template, $context, $args, $source){
    list($property, $value) = explode(" ", $args);
    if ($context->get($property) == $context->get($value)){
        return $template->render($context);
    }       
});
```
