### PR TITLE
Add "else" block to "unless" helper

### DIFF
--- a/src/Handlebars/Helpers.php
+++ b/src/Handlebars/Helpers.php
@@ -9,6 +9,7 @@
  * @package   Handlebars
  * @author    fzerorubigd <fzerorubigd@gmail.com>
  * @author    Behrooz Shabani <everplays@gmail.com>
+ * @author    Dmitriy Simushev <simushevds@gmail.com>
  * @copyright 2012 (c) ParsPooyesh Co
  * @copyright 2013 (c) Behrooz Shabani
  * @license   MIT <http://opensource.org/licenses/MIT>
@@ -150,8 +151,15 @@ class Helpers
                  * @var $source string
                  */
                 $tmp = $context->get($args);
-                $buffer = '';
+
                 if (!$tmp) {
+                    $template->setStopToken('else');
+                    $buffer = $template->render($context);
+                    $template->setStopToken(false);
+                } else {
+                    $template->setStopToken('else');
+                    $template->discard();
+                    $template->setStopToken(false);
                     $buffer = $template->render($context);
                 }
 

--- a/tests/Xamin/HandlebarsTest.php
+++ b/tests/Xamin/HandlebarsTest.php
@@ -8,6 +8,7 @@
  * @category  Xamin
  * @package   Handlebars
  * @author    fzerorubigd <fzerorubigd@gmail.com>
+ * @author    Dmitriy Simushev <simushevds@gmail.com>
  * @copyright 2013 (c) f0ruD A
  * @license   MIT <http://opensource.org/licenses/MIT>
  * @version   GIT: $Id$
@@ -170,6 +171,16 @@ class HandlebarsTest extends \PHPUnit_Framework_TestCase
             array(
                 '{{#unless data}}ok{{/unless}}',
                 array('data' => false),
+                'ok'
+            ),
+            array(
+                '{{#unless data}}ok{{else}}fail{{/unless}}',
+                array('data' => false),
+                'ok'
+            ),
+            array(
+                '{{#unless data}}fail{{else}}ok{{/unless}}',
+                array('data' => true),
                 'ok'
             ),
             array(


### PR DESCRIPTION
I've added "else" block to "unless" helper as in JavaScript version of Handlebars. One can use the following in templates:

```
{{#unless condition}}
   The condition is "falsy"
{{else}}
   The condition is true
{{/unless}}
```
