### PR TITLE
Add "else" block to "each" helper

### DIFF
--- a/src/Handlebars/Helpers.php
+++ b/src/Handlebars/Helpers.php
@@ -9,6 +9,7 @@
  * @package   Handlebars
  * @author    fzerorubigd <fzerorubigd@gmail.com>
  * @author    Behrooz Shabani <everplays@gmail.com>
+ * @author    Dmitriy Simushev <simushevds@gmail.com>
  * @copyright 2012 (c) ParsPooyesh Co
  * @copyright 2013 (c) Behrooz Shabani
  * @license   MIT <http://opensource.org/licenses/MIT>
@@ -116,7 +117,13 @@ class Helpers
                  */
                 $tmp = $context->get($args);
                 $buffer = '';
-                if (is_array($tmp) || $tmp instanceof \Traversable) {
+
+                if (!$tmp) {
+                    $template->setStopToken('else');
+                    $template->discard();
+                    $template->setStopToken(false);
+                    $buffer = $template->render($context);
+                } elseif (is_array($tmp) || $tmp instanceof \Traversable) {
                     $islist = ($tmp instanceof \Generator) || (array_keys($tmp) == range(0, count($tmp) - 1));
 
                     foreach ($tmp as $key => $var) {
@@ -126,6 +133,8 @@ class Helpers
                             $context->pushKey($key);
                         }
                         $context->push($var);
+                        $template->setStopToken('else');
+                        $template->rewind();
                         $buffer .= $template->render($context);
                         $context->pop();
                         if ($islist) {

--- a/src/Handlebars/Template.php
+++ b/src/Handlebars/Template.php
@@ -10,6 +10,7 @@
  * @author    fzerorubigd <fzerorubigd@gmail.com>
  * @author    Behrooz Shabani <everplays@gmail.com>
  * @author    Chris Gray <chris.w.gray@gmail.com>
+ * @author    Dmitriy Simushev <simushevds@gmail.com>
  * @copyright 2012 (c) ParsPooyesh Co
  * @copyright 2013 (c) Behrooz Shabani
  * @license   MIT <http://opensource.org/licenses/MIT>
@@ -228,6 +229,18 @@ class Template
         }
 
         return '';
+    }
+
+    /**
+     * Rewind top tree index to the first element
+     *
+     * @return void
+     */
+    public function rewind()
+    {
+        $topStack = array_pop($this->_stack);
+        $topStack[0] = 0;
+        array_push($this->_stack, $topStack);
     }
 
     /**

--- a/tests/Xamin/HandlebarsTest.php
+++ b/tests/Xamin/HandlebarsTest.php
@@ -8,6 +8,7 @@
  * @category  Xamin
  * @package   Handlebars
  * @author    fzerorubigd <fzerorubigd@gmail.com>
+ * @author    Dmitriy Simushev <simushevds@gmail.com>
  * @copyright 2013 (c) f0ruD A
  * @license   MIT <http://opensource.org/licenses/MIT>
  * @version   GIT: $Id$
@@ -161,6 +162,16 @@ class HandlebarsTest extends \PHPUnit_Framework_TestCase
                 '{{#each data}}{{@key}}=>{{this}}{{/each}}',
                 array('data' => array('key1'=>1, 'key2'=>2,)),
                 'key1=>1key2=>2'
+            ),
+            array(
+                '{{#each data}}{{this}}{{else}}fail{{/each}}',
+                array('data' => array(1, 2, 3, 4)),
+                '1234'
+            ),
+            array(
+                '{{#each data}}fail{{else}}ok{{/each}}',
+                array('data' => false),
+                'ok'
             ),
             array(
                 '{{#unless data}}ok{{/unless}}',


### PR DESCRIPTION
I've added "else" block to "each" helper as in JavaScript version of Handlebars. One can use the following in templates:

```
{{#each items}}
   {{this}}
{{else}}
   There are no items. Sorry.
{{/unless}}
```
