### PR TITLE
Use handlebars escape function for helpers' results

### DIFF
--- a/src/Handlebars/Template.php
+++ b/src/Handlebars/Template.php
@@ -407,9 +407,16 @@ class Template
         $current[Tokenizer::NAME] = $name;
         $current[Tokenizer::ARGS] = implode(' ', $args);
         $result = $this->_section($context, $current);
-        if ( $escaped ) {
-            $result = htmlspecialchars($result);
+
+        if ($escaped) {
+            $escape_args = $this->handlebars->getEscapeArgs();
+            array_unshift($escape_args, $result);
+            $result = call_user_func_array(
+                $this->handlebars->getEscape(),
+                array_values($escape_args)
+            );
         }
+
         return $result;
     }
 


### PR DESCRIPTION
Escape function can be changed via `\Handlebars\Handlebars::setEscape` and `\Handlebars\Handlebars::setEscapeArgs`, thus `htmlspecialchars` function cannot be used directly.
