### PR TITLE
Add segment-literal notation for expressions

### DIFF
--- a/src/Handlebars/Template.php
+++ b/src/Handlebars/Template.php
@@ -455,7 +455,7 @@ class Template
     public function parseArguments($string)
     {
         $args = array();
-        preg_match_all('#(?<!\\\\)("|\')(?:[^\\\\]|\\\\.)*?\1|\S+#s', $string, $args);
+        preg_match_all('#(?:[^\'"\[\]\s]|\[.+?\])+|(?<!\\\\)("|\')(?:[^\\\\]|\\\\.)*?\1|\S+#s', $string, $args);
         $args =  isset($args[0])?$args[0]:array();
         
         for ($x=0, $argc = count($args); $x<$argc;$x++) {

--- a/tests/Xamin/HandlebarsTest.php
+++ b/tests/Xamin/HandlebarsTest.php
@@ -476,12 +476,18 @@ class HandlebarsTest extends \PHPUnit_Framework_TestCase
     {
         $test = new stdClass();
         $test->value = 'value';
-        $test->array = array('a' => '1', 'b' => '2');
+        $test->array = array(
+            'a' => '1',
+            'b' => '2',
+            '!"#%&\'()*+,./;<=>@[\\^`{|}~ ' => '3',
+        );
         $context = new \Handlebars\Context($test);
         $this->assertEquals('value', $context->get('value'));
         $this->assertEquals('value', $context->get('value', true));
+        $this->assertEquals('value', $context->get('[value]', true));
         $this->assertEquals('1', $context->get('array.a', true));
         $this->assertEquals('2', $context->get('array.b', true));
+        $this->assertEquals('3', $context->get('array.[!"#%&\'()*+,./;<=>@[\\^`{|}~ ]', true));
         $new = array('value' => 'new value');
         $context->push($new);
         $this->assertEquals('new value', $context->get('value'));
@@ -546,7 +552,9 @@ class HandlebarsTest extends \PHPUnit_Framework_TestCase
                     array('arg1 "arg\"2" "\"arg3\""', array("arg1",'arg"2', '"arg3"')),
                     array("'arg1 arg2'", array("arg1 arg2")),
                     array("arg1 arg2 'arg number 3'", array("arg1","arg2","arg number 3")),
-                    array('arg1 "arg\"2" "\\\'arg3\\\'"', array("arg1",'arg"2', "'arg3'"))
+                    array('arg1 "arg\"2" "\\\'arg3\\\'"', array("arg1",'arg"2', "'arg3'")),
+                    array('arg1 arg2.[value\'s "segment"].val', array("arg1", 'arg2.[value\'s "segment"].val')),
+                    array('"arg1.[value 1]" arg2', array("arg1.[value 1]", 'arg2')),
         );
     }
     /**


### PR DESCRIPTION
I've added support for segment-literal notation for variables names as in Handlebars.js. In other words one can use `value.[some key]` syntax.

For example:

``` php
$engine = new \Handlebars\Handlebars();

echo $engine->render(
    '{{greetings.[hello world!]}}',
    array(
        'greetings' => array(
            "hello world!" => 'Hello from Handlebars'
        )
    )
);
```

The tests for such feature in handlebars.js are available here: http://jsfiddle.net/L7LWM/1/
