### PR TITLE
fix warning about $tmp in each-helper

### DIFF
--- a/src/Handlebars/Helpers.php
+++ b/src/Handlebars/Helpers.php
@@ -124,7 +124,7 @@ class Helpers
                     $template->setStopToken(false);
                     $buffer = $template->render($context);
                 } elseif (is_array($tmp) || $tmp instanceof \Traversable) {
-                    $islist = ($tmp instanceof \Generator) || (array_keys($tmp) == range(0, count($tmp) - 1));
+                    $islist = ($tmp instanceof \Generator) || (array_keys((array) $tmp) == range(0, count($tmp) - 1));
 
                     foreach ($tmp as $key => $var) {
                         if ($islist) {


### PR DESCRIPTION
`$tmp` might be an object that can be iterated, but array_keys expects to receive an array, so we cast it like that to suppress warnings.
