### PR TITLE
Each special variables

### DIFF
--- a/src/Handlebars/Context.php
+++ b/src/Handlebars/Context.php
@@ -67,7 +67,7 @@ class Context
 
     /**
      * @var array Special variables stack for sections. Each stack element can
-     * contain elements with "@index" and "@key" keys.
+     * contain elements with "@index", "@key", "@first" and "@last" keys.
      */
     protected $specialVariables = array();
 

--- a/src/Handlebars/Helpers.php
+++ b/src/Handlebars/Helpers.php
@@ -126,9 +126,14 @@ class Helpers
                 } elseif (is_array($tmp) || $tmp instanceof \Traversable) {
                     $isList = is_array($tmp) && (array_keys($tmp) == range(0, count($tmp) - 1));
                     $index = 0;
+                    $lastIndex = $isList ? (count($tmp) - 1) : false;
 
                     foreach ($tmp as $key => $var) {
-                        $specialVariables = array('@index' => $index);
+                        $specialVariables = array(
+                            '@index' => $index,
+                            '@first' => ($index === 0),
+                            '@last' => ($index === $lastIndex),
+                        );
                         if (!$isList) {
                             $specialVariables['@key'] = $key;
                         }

--- a/src/Handlebars/Template.php
+++ b/src/Handlebars/Template.php
@@ -293,9 +293,14 @@ class Template
             if (is_array($sectionVar) || $sectionVar instanceof \Traversable) {
                 $isList = is_array($sectionVar) && (array_keys($sectionVar) == range(0, count($sectionVar) - 1));
                 $index = 0;
+                $lastIndex = $isList ? (count($sectionVar) - 1) : false;
 
                 foreach ($sectionVar as $key => $d) {
-                    $specialVariables = array('@index' => $index);
+                    $specialVariables = array(
+                        '@index' => $index,
+                        '@first' => ($index === 0),
+                        '@last' => ($index === $lastIndex),
+                    );
                     if (!$isList) {
                         $specialVariables['@key'] = $key;
                     }

--- a/tests/Xamin/HandlebarsTest.php
+++ b/tests/Xamin/HandlebarsTest.php
@@ -184,6 +184,16 @@ class HandlebarsTest extends \PHPUnit_Framework_TestCase
                 '0=>1,1=>2,'
             ),
             array(
+                '{{#each data}}{{#if @first}}the first is {{this}}{{/if}}{{/each}}',
+                array('data' => array('one', 'two', 'three')),
+                'the first is one'
+            ),
+            array(
+                '{{#each data}}{{#if @last}}the last is {{this}}{{/if}}{{/each}}',
+                array('data' => array('one', 'two', 'three')),
+                'the last is three'
+            ),
+            array(
                 '{{#each data}}{{this}}{{else}}fail{{/each}}',
                 array('data' => array(1, 2, 3, 4)),
                 '1234'


### PR DESCRIPTION
About the PR.
There was a difference in "@index" and "@key" special variables in "#each" helper between PHP and JavaScript version of Handlebars. JS version provides "@index" for all containers (both objects and arrays) and "@key" for objects. Here is a proof fiddle: http://jsfiddle.net/5e7vS/1/. At the same time PHP version provides either "@key" or "@index" depending on a container type. 

Also, as wrote in #46 there was no "@first"/"@last" elements in "#each" helper.

About implementation.
I've assumed that only PHP arrays with sequential numeric keys are equivalent to JavaScript arrays. For such "arrays" "@index",  "@first" and "@last" special variables are available in "#each" helper.

On the other hand, all other arrays and instances of `\Traversable` are treated as JavaScript objects. For such "objects" "@index", "@key" and "@first" special variables are available in "#each" helper.
