### PR TITLE
Extra arguments escaping

### DIFF
--- a/tests/Xamin/HandlebarsTest.php
+++ b/tests/Xamin/HandlebarsTest.php
@@ -326,6 +326,13 @@ class HandlebarsTest extends \PHPUnit_Framework_TestCase
             return new \Handlebars\SafeString('<strong>Test</strong>');
         });
         $this->assertEquals('<strong>Test</strong>', $engine->render('{{safeStringTest}}', array()));
+
+        $engine->addHelper('argsTest', function($template, $context, $arg) {
+            $parsed_args = $template->parseArguments($arg);
+
+            return implode(' ', $parsed_args);
+        });
+        $this->assertEquals('a \"b\" c', $engine->render('{{argsTest "a" "\"b\"" \'c\'}}', array()));
     }
 
     public function testInvalidHelperMustacheStyle()


### PR DESCRIPTION
There is a problem with unneeded extra escaping of helpers arguments.

If one want to pass string with a character that must be escaped to a helper he should use a code like the following:

```
{{someFakeHelper "It is a \"correct\" string."}}
```

But `someFakeHelper` cannot use its argument. Due to wrong escaping it will receive a string `"It is a \\"correct\\" string."`. `\Handlebars\Template::parseArguments` method applied for the string returns the following arguments:
- string `It is a\`
- variable `correct\`
- string `string.`

Thus there is no way to specify string arguments with characters escaping in a template.

I've attach a pull request with a test for the problem.
