### PR TITLE
Fix quotes extra escape

### DIFF
--- a/src/Handlebars/Tokenizer.php
+++ b/src/Handlebars/Tokenizer.php
@@ -12,6 +12,7 @@
  * @author    Justin Hileman <dontknow@example.org>
  * @author    fzerorubigd <fzerorubigd@gmail.com>
  * @author    Behrooz Shabani <everplays@gmail.com>
+ * @author    Dmitriy Simushev <simushevds@gmail.com>
  * @copyright 2010-2012 (c) Justin Hileman
  * @copyright 2012 (c) ParsPooyesh Co
  * @copyright 2013 (c) Behrooz Shabani
@@ -129,7 +130,12 @@ class Tokenizer
 
             $this->escaping = $this->tagChange(self::T_ESCAPE, $text, $i);
 
-            if ( $this->escaped and !in_array($text[$i], array(self::T_UNESCAPED, self::T_SINGLE_Q, self::T_DOUBLE_Q)) ) {
+            // To play nice with helpers' arguments quote and apostrophe marks
+            // should be additionally escaped only when they are not in a tag.
+            $quote_in_tag = $this->state != self::IN_TEXT
+                && ($text[$i] == self::T_SINGLE_Q || $text[$i] == self::T_DOUBLE_Q);
+
+            if ($this->escaped && $text[$i] != self::T_UNESCAPED && !$quote_in_tag) {
                 $this->buffer .= "\\";
             }
 

--- a/tests/Xamin/HandlebarsTest.php
+++ b/tests/Xamin/HandlebarsTest.php
@@ -147,6 +147,16 @@ class HandlebarsTest extends \PHPUnit_Framework_TestCase
                 array(),
                 '\\\\\\\\qux'
             ),
+            array(
+                "var jsVar = 'It\'s a phrase in apos';",
+                array(),
+                "var jsVar = 'It\'s a phrase in apos';"
+            ),
+            array(
+                'var jsVar = "A \"quoted\" text";',
+                array(),
+                'var jsVar = "A \"quoted\" text";',
+            ),
         );
     }
 


### PR DESCRIPTION
It's an addition to #63.

Quote and apostrophe marks should be additionally escaped only when they are not in a tag. 
