### PR TITLE
Patch for arrays that contain only one elements

### DIFF
--- a/src/Handlebars/Helper/EachHelper.php
+++ b/src/Handlebars/Helper/EachHelper.php
@@ -10,6 +10,7 @@
  * @author    Behrooz Shabani <everplays@gmail.com>
  * @author    Dmitriy Simushev <simushevds@gmail.com>
  * @author    Jeff Turcotte <jeff.turcotte@gmail.com>
+ * @author    John Slegers <slegersjohn@gmail.com>
  * @copyright 2014 Authors
  * @license   MIT <http://opensource.org/licenses/MIT>
  * @version   GIT: $Id$
@@ -31,6 +32,7 @@ use Handlebars\Template;
  * @author    Behrooz Shabani <everplays@gmail.com>
  * @author    Dmitriy Simushev <simushevds@gmail.com>
  * @author    Jeff Turcotte <jeff.turcotte@gmail.com>
+ * @author    John Slegers <slegersjohn@gmail.com>
  * @copyright 2014 Authors
  * @license   MIT <http://opensource.org/licenses/MIT>
  * @version   Release: @package_version@


### PR DESCRIPTION
For arrays that contain only one element, `(array_keys($tmp) == range(0, count($tmp) - 1)` always returns true.

`(array_keys($tmp) === range(0, count($tmp) - 1)` works as expected.

My local test environment = Linux Mint + PHP 5.4.
