### PR TITLE
Patch 2 for arrays that contain only one elements

### DIFF
--- a/src/Handlebars/Template.php
+++ b/src/Handlebars/Template.php
@@ -13,6 +13,7 @@
  * @author    Dmitriy Simushev <simushevds@gmail.com>
  * @author    majortom731 <majortom731@googlemail.com>
  * @author    Jeff Turcotte <jeff.turcotte@gmail.com>
+ * @author    John Slegers <slegersjohn@gmail.com>
  * @copyright 2010-2012 (c) Justin Hileman
  * @copyright 2012 (c) ParsPooyesh Co
  * @copyright 2013 (c) Behrooz Shabani
@@ -353,7 +354,7 @@ class Template
         $buffer = '';
         if (is_array($sectionVar) || $sectionVar instanceof \Traversable) {
             $isList = is_array($sectionVar) &&
-                (array_keys($sectionVar) == range(0, count($sectionVar) - 1));
+                (array_keys($sectionVar) === range(0, count($sectionVar) - 1));
             $index = 0;
             $lastIndex = $isList ? (count($sectionVar) - 1) : false;
 


### PR DESCRIPTION
For arrays that contain only one element, `(array_keys($tmp) == range(0, count($tmp) - 1)` always returns true.

`(array_keys($tmp) === range(0, count($tmp) - 1)` works as expected.

My local test environment = Linux Mint + PHP 5.4.

This patch is identical to https://github.com/XaminProject/handlebars.php/pull/66, but applies to a different part of the code.
