### PR TITLE
Nested ifs are broken

### DIFF
--- a/tests/Xamin/HandlebarsTest.php
+++ b/tests/Xamin/HandlebarsTest.php
@@ -199,6 +199,11 @@ class HandlebarsTest extends \PHPUnit_Framework_TestCase
                 ''
             ),
             array(
+                '{{#if first}}The first{{else}}{{#if second}}The second{{/if}}{{/if}}',
+                array('first' => false, 'second' => true),
+                'The second'
+            ),
+            array(
                 '{{#with data}}{{key}}{{/with}}',
                 array('data' => array('key' => 'result')),
                 'result'


### PR DESCRIPTION
This PR adds a test for broken nested ifs.

At the moment I cannot really say where the bug is but it seems that a68318f4c55be035f6d82dbca3211f6dc95ccda7 brought the bug into the code.
