### PR TITLE
Add named arguments parser

### DIFF
--- a/src/Handlebars/Template.php
+++ b/src/Handlebars/Template.php
@@ -582,6 +582,49 @@ class Template
     }
 
     /**
+     * Break an argument string into an array of named arguments
+     *
+     * @param string $string Argument String as passed to a helper
+     *
+     * @return array the argument list as an array
+     */
+    public function parseNamedArguments($string)
+    {
+        $variableName = '(?:(?:[^\'"\[\]\s]|\[.+?\])+)';
+        $escapedValue = '(?:(?<!\\\\)".*?(?<!\\\\)"|(?<!\\\\)\'.*?(?<!\\\\)\')';
+
+        // Get list of named arguemnts
+        $matches = array();
+        preg_match_all(
+            '#(' . $variableName . ')\s*=\s*(' . $escapedValue . '|' . $variableName . ')#',
+            $string,
+            $matches,
+            PREG_SET_ORDER
+        );
+
+        $args = array();
+        for ($x = 0, $c = count($matches); $x < $c; $x++) {
+            $name = $matches[$x][1];
+            $value = $matches[$x][2];
+
+            // Check if argument's name is a segment
+            if ($name[0] == '[') {
+                $name = substr($name, 1, -1);
+            }
+
+            // Check if argument's value is a quoted string literal
+            if ($value[0] == "'" || $value[0] == '"') {
+                // Remove enclosing quotes and unescape
+                $value = new \Handlebars\String(stripcslashes(substr($value, 1, -1)));
+            }
+
+            $args[$name] = $value;
+        }
+
+        return $args;
+    }
+
+    /**
      * Break an argument string into an array of strings
      *
      * @param string $string Argument String as passed to a helper

--- a/tests/Xamin/HandlebarsTest.php
+++ b/tests/Xamin/HandlebarsTest.php
@@ -820,6 +820,38 @@ class HandlebarsTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($args, $expected_array);
     }
 
+    public function namedArgumentParserProvider()
+    {
+        return array(
+            array('arg1="value" arg2="value 2"', array('arg1' => 'value', 'arg2' => 'value 2')),
+            array('arg1=var1', array('arg1' => 'var1')),
+            array('[arg "1"]="arg number 1"', array('arg "1"' => "arg number 1")),
+            array('arg1 =   "value"', array('arg1' => "value")),
+        );
+    }
+
+    /**
+     * Test Named Argument Parser
+     *
+     * @param string $arg_string argument text
+     * @param        $expected_array
+     *
+     * @dataProvider namedArgumentParserProvider
+     *
+     * @return void
+     */
+    public function testNamedArgumentsParser($arg_string, $expected_array)
+    {
+        $engine = new \Handlebars\Handlebars();
+        $template = new \Handlebars\Template($engine, null, null);
+        // get the string version of the arguments array
+        $args = $template->parseNamedArguments($arg_string);
+        $args = array_map(function ($a) {
+            return (string)$a;
+        }, $args);
+        $this->assertEquals($args, $expected_array);
+    }
+
     public function stringLiteralInCustomHelperProvider()
     {
         return array(


### PR DESCRIPTION
Added a parser for named arguments.

Though a PR for the problem already exists (see #44), it seems abandoned. Thus I've implemented the same feature in a different way.
