### PR TITLE
Update Context.php

### DIFF
--- a/src/Handlebars/Context.php
+++ b/src/Handlebars/Context.php
@@ -253,7 +253,7 @@ class Context
      */
     private function _findVariableInContext($variable, $inside, $strict = false)
     {
-        $value = '';
+        $value = null;
         if (($inside !== '0' && empty($inside)) || ($inside == 'this')) {
             return $variable;
         } elseif (is_array($variable)) {


### PR DESCRIPTION
Should return null instead of an empty string when context is not found. Handlebars.js returns undefined, which makes it possible to distict an empty string and not existing. (should not affect existing use, because null is handeled the same way as empty string)
