### PR TITLE
Fix arguments parsing for "0" string

### DIFF
--- a/src/Handlebars/Arguments.php
+++ b/src/Handlebars/Arguments.php
@@ -56,9 +56,9 @@ class Arguments
      */
     public function __construct($args_string = false)
     {
-        $this->originalString = $args_string;
+        $this->originalString = (string)$args_string;
 
-        if ($args_string) {
+        if ($this->originalString !== '') {
             $this->parse($args_string);
         }
     }

--- a/tests/Xamin/HandlebarsTest.php
+++ b/tests/Xamin/HandlebarsTest.php
@@ -801,6 +801,7 @@ class HandlebarsTest extends \PHPUnit_Framework_TestCase
             array('arg1 "arg\"2" "\\\'arg3\\\'"', array("arg1", 'arg"2', "'arg3'")),
             array('arg1 arg2.[value\'s "segment"].val', array("arg1", 'arg2.[value\'s "segment"].val')),
             array('"arg1.[value 1]" arg2', array("arg1.[value 1]", 'arg2')),
+            array('0', array('0')),
         );
     }
 


### PR DESCRIPTION
At the moment arguments string which contains only one "zero" character ("`0`") is treated as an empty string and is not correctly parsed via `Arguments` class.

I've fixed this problem with the PR.
