### PR TITLE
Return integers "as is" from the context

### DIFF
--- a/src/Handlebars/Context.php
+++ b/src/Handlebars/Context.php
@@ -188,6 +188,11 @@ class Context
         if ($variableName instanceof \Handlebars\String) {
             return (string)$variableName;
         }
+        if (preg_match("/^-?\d+$/", $variableName)) {
+            // Real variable name cannot contain only numbers, thus an integer
+            // value is found.
+            return intval($variableName);
+        }
         $variableName = trim($variableName);
         $level = 0;
         while (substr($variableName, 0, 3) == '../') {

--- a/tests/Xamin/HandlebarsTest.php
+++ b/tests/Xamin/HandlebarsTest.php
@@ -747,6 +747,11 @@ class HandlebarsTest extends \PHPUnit_Framework_TestCase
         $context->pop();
         $this->assertEquals('value', $context->get('value'));
         $this->assertEquals('value', $context->get('value', true));
+        // Check that integers are returned from the context as is.
+        $this->assertEquals(-15, $context->get(-15));
+        $this->assertEquals(0, $context->get(0));
+        $this->assertEquals(10, $context->get(10));
+        $this->assertEquals(123, $context->get('123'));
     }
 
     /**


### PR DESCRIPTION
A valid variable name cannot be an integer, thus if an integer is passed in to the `Context::get` method it should be returned as is.
