### PR TITLE
Treat integer helper arguments as literals

### DIFF
--- a/src/Handlebars/Arguments.php
+++ b/src/Handlebars/Arguments.php
@@ -162,7 +162,14 @@ class Arguments
         // Check if argument's value is a quoted string literal
         if ($value[0] == "'" || $value[0] == '"') {
             // Remove enclosing quotes and unescape
-            $value = new String(stripcslashes(substr($value, 1, -1)));
+            return new String(stripcslashes(substr($value, 1, -1)));
+        }
+
+        // Check if the value is an integer literal
+        if (preg_match("/^-?\d+$/", $value)) {
+            // Wrap the value into the String class to tell the Context that
+            // it's a value and not a variable name.
+            return new String($value);
         }
 
         return $value;

--- a/tests/Xamin/HandlebarsTest.php
+++ b/tests/Xamin/HandlebarsTest.php
@@ -974,6 +974,43 @@ class HandlebarsTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($res, $results);
     }
 
+    public function integerLiteralInCustomHelperProvider()
+    {
+        return array(
+            array('{{test -5}}', array(), '-5'),
+            array('{{test 0}}', array(), '0'),
+            array('{{test 12}}', array(), '12'),
+            array('{{test 12 [12]}}', array('12' => 'foo'), '12:foo'),
+        );
+    }
+
+    /**
+     * Test integer literals in the context of a helper
+     *
+     * @param string $template template text
+     * @param array  $data     context data
+     * @param string $results  The Expected Results
+     *
+     * @dataProvider integerLiteralInCustomHelperProvider
+     *
+     * @return void
+     */
+    public function testIntegerLiteralInCustomHelper($template, $data, $results)
+    {
+        $engine = new \Handlebars\Handlebars();
+        $engine->addHelper('test', function ($template, $context, $args) {
+            $args = $template->parseArguments($args);
+
+            $args = array_map(function ($a) use ($context) {
+                return $context->get($a);
+            }, $args);
+
+            return implode(':', $args);
+        });
+        $res = $engine->render($template, $data);
+        $this->assertEquals($res, $results);
+    }
+
     public function testString()
     {
         $string = new \Handlebars\String("Hello World");


### PR DESCRIPTION
A valid variable name cannot be an integer. Thus if an integer is used as a helper argument it should be treated as a literal and not as variable name.

Here is a JS fiddle that demonstrates such behavior in Handlebars.js http://jsfiddle.net/vr82ocb1/2/
