### PR TITLE
Make subexpressions play nice with context

### DIFF
--- a/src/Handlebars/Template.php
+++ b/src/Handlebars/Template.php
@@ -354,9 +354,9 @@ class Template
                     Tokenizer::ARGS => implode(" ", array_slice($cmd, 1))
                 );
                 // resolve the node recursively
-                $resolved = $this->_handlebarsStyleSection($context, $section_node);
+                $resolved = addcslashes($this->_handlebarsStyleSection($context, $section_node), '"');
                 // replace original subexpression with result
-                $current[Tokenizer::ARGS] = str_replace('('.$expr.')', $resolved, $current[Tokenizer::ARGS]);
+                $current[Tokenizer::ARGS] = str_replace('('.$expr.')', '"' . $resolved . '"', $current[Tokenizer::ARGS]);
             }
         }
 


### PR DESCRIPTION
I believe I've made subexpressions work with context. It's related with #80.
