### PR TITLE
Added getCurrentTokenTree to get a token's tree within a helper

### DIFF
--- a/src/Handlebars/Template.php
+++ b/src/Handlebars/Template.php
@@ -129,6 +129,18 @@ class Template
     }
 
     /**
+     * Get the current token's tree
+     *
+     * @return array
+     */
+    public function getCurrentTokenTree()
+    {
+        $topStack = end($this->_stack);
+
+        return $topStack[1];
+    }
+
+    /**
      * Render top tree
      *
      * @param mixed $context current context


### PR DESCRIPTION
I have a custom Helper where I wish to get the piece of the tree associated with my token in order to "reflect" the contents. Currently, I am limited to getting the template's full tree through the Template instance. The only way to do what I want was to re-parse the $source variable that is passed to the helper, which is OK, but felt very inefficient. I think this is a pretty simple solution to the problem at hand, but let me know if there is a better way, better naming, etc. Thanks!
