### PR TITLE
Return 'Array' when referencing an array as a string

### DIFF
--- a/src/Handlebars/Template.php
+++ b/src/Handlebars/Template.php
@@ -581,6 +581,9 @@ class Template
     {
         $name = $current[Tokenizer::NAME];
         $value = $context->get($name);
+        if (is_array($value)) {
+            return 'Array';
+        }
         if ($escaped) {
             $args = $this->handlebars->getEscapeArgs();
             array_unshift($args, $value);

--- a/tests/Xamin/HandlebarsTest.php
+++ b/tests/Xamin/HandlebarsTest.php
@@ -711,6 +711,8 @@ class HandlebarsTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('var-y-z', $engine->render('{{var.y.z}}', array('var' => $var)));
         // Access parent context in with helper
         $this->assertEquals('var-x', $engine->render('{{#with var.y}}{{../var.x}}{{/with}}', array('var' => $var)));
+        // Reference array as string
+        $this->assertEquals('Array', $engine->render('{{var}}', array('var' => array('test'))));
 
         $obj = new DateTime();
         $time = $obj->getTimestamp();


### PR DESCRIPTION
Squashed version of #95 with added test
When using `{{value}}` on an array, It bombs out with an error. This is to simply return the string 'Array' similar to how PHP does it (without the error) or how javascript does `[Object object]`
