### PR TITLE
Use more restictive dependencies versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,8 @@
 
     },
     "require-dev": {
-        "phpunit/phpunit": "@stable",
-        "squizlabs/php_codesniffer": "@stable"
+        "phpunit/phpunit": "~4.4",
+        "squizlabs/php_codesniffer": "~1.5"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
PHPCS checks now fail because code sniffer automatically switches from 1.x branch to 2.x. I'm proposing to use more restrictive versions for composer dependencies to avoid such problems in the future.
