### PR TITLE
Added custom template class option

### DIFF
--- a/src/Handlebars/Handlebars.php
+++ b/src/Handlebars/Handlebars.php
@@ -9,6 +9,7 @@
  * @package   Handlebars
  * @author    fzerorubigd <fzerorubigd@gmail.com>
  * @author    Behrooz Shabani <everplays@gmail.com>
+ * @author    Jeff Turcotte <jeff.turcotte@gmail.com>
  * @copyright 2010-2012 (c) Justin Hileman
  * @copyright 2012 (c) ParsPooyesh Co
  * @copyright 2013 (c) Behrooz Shabani
@@ -85,6 +86,11 @@ class Handlebars
     private $_cache;
 
     /**
+     * @var string the class to use for the template
+     */
+    private $_templateClass = 'Handlebars\\Template';
+
+    /**
      * @var callable escape function to use
      */
     private $_escape = 'htmlspecialchars';
@@ -108,6 +114,7 @@ class Handlebars
      * loader         => Loader object
      * partials_loader => Loader object
      * cache          => Cache object
+     * template_class => the class to use for the template object
      *
      * @param array $options array of options to set
      *
@@ -129,6 +136,10 @@ class Handlebars
 
         if (isset($options['cache'])) {
             $this->setCache($options['cache']);
+        }
+
+        if (isset($options['template_class'])) {
+            $this->setTemplateClass($options['template_class']);
         }
 
         if (isset($options['escape'])) {
@@ -439,6 +450,24 @@ class Handlebars
     }
 
     /**
+     * Sets the class to use for the template object
+     *
+     * @param string $class the class name
+     *
+     * @return void
+     */
+    public function setTemplateClass($class)
+    {
+        if (!is_a($class, 'Handlebars\\Template', true)) {
+            throw new \InvalidArgumentException(
+                'Custom template class must extend Template'
+            );
+        }
+
+        $this->_templateClass = $class;
+    }
+
+    /**
      * Load a template by name with current template loader
      *
      * @param string $name template name
@@ -450,7 +479,7 @@ class Handlebars
         $source = $this->getLoader()->load($name);
         $tree = $this->_tokenize($source);
 
-        return new Template($this, $tree, $source);
+        return new $this->_templateClass($this, $tree, $source);
     }
 
     /**
@@ -468,7 +497,7 @@ class Handlebars
         $source = $this->getPartialsLoader()->load($name);
         $tree = $this->_tokenize($source);
 
-        return new Template($this, $tree, $source);
+        return new $this->_templateClass($this, $tree, $source);
     }
 
     /**
@@ -509,7 +538,7 @@ class Handlebars
     {
         $tree = $this->_tokenize($source);
 
-        return new Template($this, $tree, $source);
+        return new $this->_templateClass($this, $tree, $source);
     }
 
     /**

--- a/src/Handlebars/Template.php
+++ b/src/Handlebars/Template.php
@@ -45,9 +45,14 @@ class Template
      */
     protected $handlebars;
 
-
+    /**
+     * @var array The tokenized tree
+     */
     protected $tree = array();
 
+    /**
+     * @var string The template source
+     */
     protected $source = '';
 
     /**

--- a/tests/Xamin/HandlebarsTest.php
+++ b/tests/Xamin/HandlebarsTest.php
@@ -780,6 +780,39 @@ class HandlebarsTest extends \PHPUnit_Framework_TestCase
         );
     }
 
+
+    /**
+     * Test invalid custom template class
+     *
+     * @expectedException \InvalidArgumentException
+     */
+    public function testInvalidCustomTemplateClass()
+    {
+        $loader = new \Handlebars\Loader\StringLoader();
+        $engine = new \Handlebars\Handlebars(array(
+            'loader' => $loader,
+            'template_class' => 'stdclass'
+        ));
+    }
+
+    /**
+     * Test custom template class
+     */
+    public function testValidCustomTemplateClass()
+    {
+        Handlebars\Autoloader::register(realpath(__DIR__ . '/../fixture/'));
+
+        $loader = new \Handlebars\Loader\StringLoader();
+        $engine = new \Handlebars\Handlebars(array(
+            'loader' => $loader,
+            'template_class' => 'Handlebars\CustomTemplate'
+        ));
+
+        $render = $engine->render('Original Template', array());
+
+        $this->assertEquals($render, 'Altered Template');
+    }
+
     /**
      * Test for proper handling of the length property
      **/

--- a/tests/fixture/Handlebars/CustomTemplate.php
+++ b/tests/fixture/Handlebars/CustomTemplate.php
@@ -1,0 +1,12 @@
+<?php
+namespace Handlebars;
+
+use Handlebars\Template;
+
+class CustomTemplate extends Template
+{
+    public function render($context)
+    {
+        return 'Altered Template';
+    }
+}


### PR DESCRIPTION
This enhancement is fully backwards compatible and is meant to replicate some of the extensibility that is available in Twig.

My specific use case involves custom loaders/template classes that read yaml front-matter which can alter the context. I was able to achieve this in Twig through the use of a loader and their 'base_template_class' option and wanted to achieve similar functionality with this lib, so I added a 'template_class' option. The Template object now also receives it's name (when applicable) as that is important to retrieve any metadata that may be associated with it. 

The new option ensures the class is a subclass of Handlebars\Template so current type hints continue to work throughout library code and custom helpers that developers may have written. Let me know if you have any comments/questions.

Usage: 

``` php
<?php
use Handlebars\Loader\FilesystemLoader;
use Handlebars\Handlebars;
use Handlebars\Template;

class CustomTemplate extends Template {
    public function render($context)
    {
        // do whatever I want!
    }
}

$handlebars = new Handlebars([
    'loader' => new FilesystemLoader('/path'),
    'template_class' => 'CustomTemplate'
]);
```
