### PR TITLE
Fixes and Tests for #105

### DIFF
--- a/src/Handlebars/Helper/IfHelper.php
+++ b/src/Handlebars/Helper/IfHelper.php
@@ -52,7 +52,11 @@ class IfHelper implements Helper
     {
         if (is_numeric($args)) {
             $tmp = $args;
-        } else {
+        } elseif(preg_match('/^\'.*\'$/', trim($args))) {
+        	$tmp = preg_replace('/^\'(.*)\'$/', '$1', trim($args));
+        } elseif(preg_match('/^".*"$/', trim($args))) {
+        	$tmp = preg_replace('/^"(.*)"$/', '$1', trim($args));
+		} else {
             $tmp = $context->get($args);
         }
 

--- a/src/Handlebars/Helper/IfHelper.php
+++ b/src/Handlebars/Helper/IfHelper.php
@@ -51,7 +51,7 @@ class IfHelper implements Helper
     public function execute(Template $template, Context $context, $args, $source)
     {
         $parsedArgs = $template->parseArguments($args);
-$tmp = $context->get($parsedArgs[0]);
+		$tmp = $context->get($parsedArgs[0]);
 
         $context->push($context->last());
         if ($tmp) {

--- a/src/Handlebars/Helper/IfHelper.php
+++ b/src/Handlebars/Helper/IfHelper.php
@@ -50,15 +50,8 @@ class IfHelper implements Helper
      */
     public function execute(Template $template, Context $context, $args, $source)
     {
-        if (is_numeric($args)) {
-            $tmp = $args;
-        } elseif(preg_match('/^\'.*\'$/', trim($args))) {
-        	$tmp = preg_replace('/^\'(.*)\'$/', '$1', trim($args));
-        } elseif(preg_match('/^".*"$/', trim($args))) {
-        	$tmp = preg_replace('/^"(.*)"$/', '$1', trim($args));
-		} else {
-            $tmp = $context->get($args);
-        }
+        $parsedArgs = $template->parseArguments($args);
+$tmp = $context->get($parsedArgs[0]);
 
         $context->push($context->last());
         if ($tmp) {

--- a/src/Handlebars/Helper/UnlessHelper.php
+++ b/src/Handlebars/Helper/UnlessHelper.php
@@ -50,15 +50,8 @@ class UnlessHelper implements Helper
      */
     public function execute(Template $template, Context $context, $args, $source)
     {
-    	if (is_numeric($args)) {
-            $tmp = $args;
-        } elseif(preg_match('/^\'.*\'$/', trim($args))) {
-        	$tmp = preg_replace('/^\'(.*)\'$/', '$1', trim($args));
-        } elseif(preg_match('/^".*"$/', trim($args))) {
-        	$tmp = preg_replace('/^"(.*)"$/', '$1', trim($args));
-		} else {
-            $tmp = $context->get($args);
-        }
+    	$parsedArgs = $template->parseArguments($args);
+		$tmp = $context->get($parsedArgs[0]);
 
         $context->push($context->last());
 

--- a/src/Handlebars/Helper/UnlessHelper.php
+++ b/src/Handlebars/Helper/UnlessHelper.php
@@ -50,7 +50,15 @@ class UnlessHelper implements Helper
      */
     public function execute(Template $template, Context $context, $args, $source)
     {
-        $tmp = $context->get($args);
+    	if (is_numeric($args)) {
+            $tmp = $args;
+        } elseif(preg_match('/^\'.*\'$/', trim($args))) {
+        	$tmp = preg_replace('/^\'(.*)\'$/', '$1', trim($args));
+        } elseif(preg_match('/^".*"$/', trim($args))) {
+        	$tmp = preg_replace('/^"(.*)"$/', '$1', trim($args));
+		} else {
+            $tmp = $context->get($args);
+        }
 
         $context->push($context->last());
 

--- a/tests/Xamin/HandlebarsTest.php
+++ b/tests/Xamin/HandlebarsTest.php
@@ -1155,4 +1155,54 @@ class HandlebarsTest extends \PHPUnit_Framework_TestCase
         $args = new \Handlebars\Arguments($argsString);
         $this->assertEquals($argsString, (string)$args);
     }
+    
+    
+    public function stringLiteralsInIfAndUnlessHelpersProvider() {
+    	return array(
+            // IfHelper
+    		array('{{#if "truthyString"}}true{{else}}false{{/if}}', array(), "true"),
+            array("{{#if 'truthyStringSingleQuotes'}}true{{else}}false{{/if}}", array(), "true"),
+            array("{{#if ''}}true{{else}}false{{/if}}", array(), "false"),  
+            array("{{#if '0'}}true{{else}}false{{/if}}", array(), "false"),
+            array("{{#if (add 0 1)}}true{{else}}false{{/if}}", array(), "true"),
+            array("{{#if (add 1 -1)}}true{{else}}false{{/if}}", array(), "false"),
+			// UnlessHelper
+    		array('{{#unless "truthyString"}}true{{else}}false{{/unless}}', array(), "false"),
+            array("{{#unless 'truthyStringSingleQuotes'}}true{{else}}false{{/unless}}", array(), "false"),
+            array("{{#unless ''}}true{{else}}false{{/unless}}", array(), "true"),  
+            array("{{#unless '0'}}true{{else}}false{{/unless}}", array(), "true"),
+            array("{{#unless (add 0 1)}}true{{else}}false{{/unless}}", array(), "false"),
+            array("{{#unless (add 1 -1)}}true{{else}}false{{/unless}}", array(), "true"),
+        );
+    }
+    
+   /**
+     * Test integer literals in the context of if and unless helpers
+     *
+     * @param string $template template text
+     * @param array  $data     context data
+     * @param string $results  The Expected Results
+     *
+     * @dataProvider stringLiteralsInIfAndUnlessHelpersProvider
+     *
+     * @return void
+     */
+    public function testStringLiteralsInIfAndUnlessHelpers($template, $data, $results)
+    {
+        $engine = new \Handlebars\Handlebars();
+        
+        $engine->addHelper('add', function ($template, $context, $args) {
+        	$sum = 0;
+        
+        	foreach ($template->parseArguments($args) as $value) {
+        		$sum += intval($context->get($value));
+        	}
+        
+        	return $sum;
+        });
+        
+        $res = $engine->render($template, $data);
+        $this->assertEquals($res, $results);
+    }
+    
 }

--- a/tests/Xamin/HandlebarsTest.php
+++ b/tests/Xamin/HandlebarsTest.php
@@ -1177,7 +1177,7 @@ class HandlebarsTest extends \PHPUnit_Framework_TestCase
     }
     
    /**
-     * Test integer literals in the context of if and unless helpers
+     * Test string literals in the context of if and unless helpers
      *
      * @param string $template template text
      * @param array  $data     context data


### PR DESCRIPTION
updated if and unless helpers so that if the $arg is wrapped in quotes or double quotes, it's unwrapped and then interpreted as is, instead of trying to look up any non-numeric value in the $context.