### PR TITLE
Added support for @first and @last in each helper; closes #110

### DIFF
--- a/src/Handlebars/Helpers.php
+++ b/src/Handlebars/Helpers.php
@@ -106,7 +106,13 @@ class Handlebars_Helpers
 		if (is_array($tmp) || $tmp instanceof Traversable) {
 			$islist = ( array_keys($tmp) == range(0, count($tmp) - 1) );
 
+			$index = 0;
 			foreach ($tmp as $key => $var) {
+
+				$var['@first'] = (!array_key_exists('@first', $var)) ? ($index === 0) : $var['@first'];
+				$var['@last']  = (!array_key_exists('@last', $var))  ? ($index === count($tmp)-1) : $var['@last'];
+				$index++;
+
 				if( $islist ) {
 					$context->pushIndex($key);
 				} else {


### PR DESCRIPTION
When using the `{{#each}}` helper, the variables `@first` and `@last` should be set to the boolean TRUE or FALSE to indicate if the current item is the first or last of the array. 

This code works when using the following template syntax, even with many nested loops:

```handlebars
{{#each machine}}
    The machine is made up of these parts:
    {{#each parts}}
    <li>{{part_name}}</li>
    {{/each}}
{{/each}}

```

However, this will not work if the helper is not explicitly called. For example, this code will not receive the `@first` and `@last` variables:

```handlebars
{{# machine}}
    The machine is made up of these parts:
{{/ machine}}
```

#### TO-DO: 

Move this logic to the Template.php file so that these special variables can be set when iterating over blocks that do not explicitly use the `{{#each}}` helper tag. 