### PR TITLE
Partial support and error reporting

### DIFF
--- a/src/Handlebars/Arguments.php
+++ b/src/Handlebars/Arguments.php
@@ -144,7 +144,7 @@ class Arguments
             } else {
                 throw new \InvalidArgumentException(sprintf(
                     'Malformed arguments string: "%s"',
-                    $args_string
+                    var_export($args_String, true)
                 ));
             }
         }

--- a/src/Handlebars/Arguments.php
+++ b/src/Handlebars/Arguments.php
@@ -142,7 +142,10 @@ class Arguments
                 // Remove found argument from arguments string.
                 $current_str = ltrim(substr($current_str, strlen($matches[0])));
             } else {
-                throw new \InvalidArgumentException('Malformed arguments string');
+                throw new \InvalidArgumentException(sprintf(
+                    'Malformed arguments string: "%s"',
+                    $args_string
+                ));
             }
         }
     }

--- a/src/Handlebars/Arguments.php
+++ b/src/Handlebars/Arguments.php
@@ -145,7 +145,7 @@ class Arguments
                 throw new \InvalidArgumentException(
                     sprintf(
                         'Malformed arguments string: "%s"',
-                        var_export($args_string, true)
+                        $args_string
                     )
                 );
             }

--- a/src/Handlebars/Arguments.php
+++ b/src/Handlebars/Arguments.php
@@ -142,10 +142,12 @@ class Arguments
                 // Remove found argument from arguments string.
                 $current_str = ltrim(substr($current_str, strlen($matches[0])));
             } else {
-                throw new \InvalidArgumentException(sprintf(
-                    'Malformed arguments string: "%s"',
-                    var_export($args_String, true)
-                ));
+                throw new \InvalidArgumentException(
+                    sprintf(
+                        'Malformed arguments string: "%s"',
+                        var_export($args_string, true)
+                    )
+                );
             }
         }
     }

--- a/src/Handlebars/Context.php
+++ b/src/Handlebars/Context.php
@@ -196,9 +196,10 @@ class Context
         }
         if (count($this->stack) < $level) {
             if ($strict) {
-                throw new \InvalidArgumentException(
-                    'can not find variable in context'
-                );
+                throw new \InvalidArgumentException(sprintf(
+                    'Can not find variable in context: "%s"',
+                    $variableName
+                ));
             }
 
             return '';
@@ -215,10 +216,12 @@ class Context
         $current = current($this->stack);
         if (!$variableName) {
             if ($strict) {
-                throw new \InvalidArgumentException(
-                    'can not find variable in context'
-                );
+                throw new \InvalidArgumentException(sprintf(
+                    'Can not find variable in context: "%s"',
+                    $variableName
+                ));
             }
+
             return '';
         } elseif ($variableName == '.' || $variableName == 'this') {
             return $current;
@@ -227,9 +230,10 @@ class Context
             if (isset($specialVariables[$variableName])) {
                 return $specialVariables[$variableName];
             } elseif ($strict) {
-                throw new \InvalidArgumentException(
-                    'can not find variable in context'
-                );
+                throw new \InvalidArgumentException(sprintf(
+                    'Can not find variable in context: "%s"',
+                    $variableName
+                ));
             } else {
                 return '';
             }
@@ -275,7 +279,10 @@ class Context
         }
 
         if ($strict) {
-            throw new \InvalidArgumentException('can not find variable in context');
+            throw new \InvalidArgumentException(sprintf(
+                'Can not find variable in context: "%s"',
+                $variable
+            ));
         }
 
         return $value;
@@ -299,7 +306,10 @@ class Context
         $get_pattern = "/(?:" . $name_pattern . ")/";
 
         if (!preg_match($check_pattern, $variableName)) {
-            throw new \InvalidArgumentException('variable name is invalid');
+            throw new \InvalidArgumentException(sprintf(
+                'Variable name is invalid: "%s"',
+                $variableName
+            ));
         }
 
         preg_match_all($get_pattern, $variableName, $matches);

--- a/src/Handlebars/Context.php
+++ b/src/Handlebars/Context.php
@@ -199,7 +199,7 @@ class Context
                 throw new \InvalidArgumentException(
                     sprintf(
                         'Can not find variable in context: "%s"',
-                        var_export($variableName, true)
+                        $variableName
                     )
                 );
             }
@@ -221,7 +221,7 @@ class Context
                 throw new \InvalidArgumentException(
                     sprintf(
                         'Can not find variable in context: "%s"',
-                        var_export($variableName, true)
+                        $variableName
                     )
                 );
             }
@@ -237,7 +237,7 @@ class Context
                 throw new \InvalidArgumentException(
                     sprintf(
                         'Can not find variable in context: "%s"',
-                        var_export($variableName, true)
+                        $variableName
                     )
                 );
             } else {

--- a/src/Handlebars/Context.php
+++ b/src/Handlebars/Context.php
@@ -196,10 +196,12 @@ class Context
         }
         if (count($this->stack) < $level) {
             if ($strict) {
-                throw new \InvalidArgumentException(sprintf(
-                    'Can not find variable in context: "%s"',
-                    var_export($variableName, true)
-                ));
+                throw new \InvalidArgumentException(
+                    sprintf(
+                        'Can not find variable in context: "%s"',
+                        var_export($variableName, true)
+                    )
+                );
             }
 
             return '';
@@ -216,10 +218,12 @@ class Context
         $current = current($this->stack);
         if (!$variableName) {
             if ($strict) {
-                throw new \InvalidArgumentException(sprintf(
-                    'Can not find variable in context: "%s"',
-                    var_export($variableName, true)
-                ));
+                throw new \InvalidArgumentException(
+                    sprintf(
+                        'Can not find variable in context: "%s"',
+                        var_export($variableName, true)
+                    )
+                );
             }
 
             return '';
@@ -230,10 +234,12 @@ class Context
             if (isset($specialVariables[$variableName])) {
                 return $specialVariables[$variableName];
             } elseif ($strict) {
-                throw new \InvalidArgumentException(sprintf(
-                    'Can not find variable in context: "%s"',
-                    var_export($variableName, true)
-                ));
+                throw new \InvalidArgumentException(
+                    sprintf(
+                        'Can not find variable in context: "%s"',
+                        var_export($variableName, true)
+                    )
+                );
             } else {
                 return '';
             }
@@ -279,10 +285,12 @@ class Context
         }
 
         if ($strict) {
-            throw new \InvalidArgumentException(sprintf(
-                'Can not find variable in context: "%s"',
-                var_export($variable, true)
-            ));
+            throw new \InvalidArgumentException(
+                sprintf(
+                    'Can not find variable in context: "%s"',
+                    var_export($variable, true)
+                )
+            );
         }
 
         return $value;
@@ -306,10 +314,12 @@ class Context
         $get_pattern = "/(?:" . $name_pattern . ")/";
 
         if (!preg_match($check_pattern, $variableName)) {
-            throw new \InvalidArgumentException(sprintf(
-                'Variable name is invalid: "%s"',
-                $variableName
-            ));
+            throw new \InvalidArgumentException(
+                sprintf(
+                    'Variable name is invalid: "%s"',
+                    $variableName
+                )
+            );
         }
 
         preg_match_all($get_pattern, $variableName, $matches);

--- a/src/Handlebars/Context.php
+++ b/src/Handlebars/Context.php
@@ -198,7 +198,7 @@ class Context
             if ($strict) {
                 throw new \InvalidArgumentException(sprintf(
                     'Can not find variable in context: "%s"',
-                    $variableName
+                    var_export($variableName, true)
                 ));
             }
 
@@ -218,7 +218,7 @@ class Context
             if ($strict) {
                 throw new \InvalidArgumentException(sprintf(
                     'Can not find variable in context: "%s"',
-                    $variableName
+                    var_export($variableName, true)
                 ));
             }
 
@@ -232,7 +232,7 @@ class Context
             } elseif ($strict) {
                 throw new \InvalidArgumentException(sprintf(
                     'Can not find variable in context: "%s"',
-                    $variableName
+                    var_export($variableName, true)
                 ));
             } else {
                 return '';
@@ -281,7 +281,7 @@ class Context
         if ($strict) {
             throw new \InvalidArgumentException(sprintf(
                 'Can not find variable in context: "%s"',
-                $variable
+                var_export($variable, true)
             ));
         }
 

--- a/src/Handlebars/Handlebars.php
+++ b/src/Handlebars/Handlebars.php
@@ -462,7 +462,7 @@ class Handlebars
             throw new \InvalidArgumentException(
                 sprintf(
                     'Custom template class "%s" must extend Template',
-                    var_export($class, true)
+                    $class
                 )
             );
         }

--- a/src/Handlebars/Handlebars.php
+++ b/src/Handlebars/Handlebars.php
@@ -460,7 +460,8 @@ class Handlebars
     {
         if (!is_a($class, 'Handlebars\\Template', true)) {
             throw new \InvalidArgumentException(
-                'Custom template class must extend Template'
+                'Custom template class "%s" must extend Template',
+                $class
             );
         }
 

--- a/src/Handlebars/Handlebars.php
+++ b/src/Handlebars/Handlebars.php
@@ -459,10 +459,10 @@ class Handlebars
     public function setTemplateClass($class)
     {
         if (!is_a($class, 'Handlebars\\Template', true)) {
-            throw new \InvalidArgumentException(
+            throw new \InvalidArgumentException(sprintf(
                 'Custom template class "%s" must extend Template',
-                $class
-            );
+                var_export($class, true)
+            ));
         }
 
         $this->_templateClass = $class;

--- a/src/Handlebars/Handlebars.php
+++ b/src/Handlebars/Handlebars.php
@@ -459,10 +459,12 @@ class Handlebars
     public function setTemplateClass($class)
     {
         if (!is_a($class, 'Handlebars\\Template', true)) {
-            throw new \InvalidArgumentException(sprintf(
-                'Custom template class "%s" must extend Template',
-                var_export($class, true)
-            ));
+            throw new \InvalidArgumentException(
+                sprintf(
+                    'Custom template class "%s" must extend Template',
+                    var_export($class, true)
+                )
+            );
         }
 
         $this->_templateClass = $class;

--- a/src/Handlebars/Helpers.php
+++ b/src/Handlebars/Helpers.php
@@ -99,9 +99,10 @@ class Helpers
     public function add($name, $helper)
     {
         if (!is_callable($helper) && ! $helper instanceof Helper) {
-            throw new \InvalidArgumentException(
-                "$name Helper is not a callable or doesn't implement the Helper interface."
-            );
+            throw new \InvalidArgumentException(sprintf(
+                "%s Helper is not a callable or doesn't implement the Helper interface.",
+                $name
+            ));
         }
         $this->helpers[$name] = $helper;
     }
@@ -136,7 +137,10 @@ class Helpers
     public function call($name, Template $template, Context $context, $args, $source)
     {
         if (!$this->has($name)) {
-            throw new \InvalidArgumentException('Unknown helper: ' . $name);
+            throw new \InvalidArgumentException(sprintf(
+                'Unknown helper: "%s"',
+                $name
+            ));
         }
 
         if ($this->helpers[$name] instanceof Helper) {
@@ -171,7 +175,10 @@ class Helpers
     public function __get($name)
     {
         if (!$this->has($name)) {
-            throw new \InvalidArgumentException('Unknown helper :' . $name);
+            throw new \InvalidArgumentException(sprintf(
+                'Unknown helper: "%s"',
+                $name
+            ));
         }
 
         return $this->helpers[$name];
@@ -226,7 +233,10 @@ class Helpers
     public function remove($name)
     {
         if (!$this->has($name)) {
-            throw new \InvalidArgumentException('Unknown helper: ' . $name);
+            throw new \InvalidArgumentException(sprintf(
+                'Unknown helper: "%s"',
+                $name
+            ));
         }
 
         unset($this->helpers[$name]);

--- a/src/Handlebars/Helpers.php
+++ b/src/Handlebars/Helpers.php
@@ -99,10 +99,12 @@ class Helpers
     public function add($name, $helper)
     {
         if (!is_callable($helper) && ! $helper instanceof Helper) {
-            throw new \InvalidArgumentException(sprintf(
-                "%s Helper is not a callable or doesn't implement the Helper interface.",
-                var_export($name, true)
-            ));
+            throw new \InvalidArgumentException(
+                sprintf(
+                    "%s Helper is not a callable or doesn't implement the Helper interface.",
+                    var_export($name, true)
+                )
+            );
         }
         $this->helpers[$name] = $helper;
     }
@@ -137,10 +139,12 @@ class Helpers
     public function call($name, Template $template, Context $context, $args, $source)
     {
         if (!$this->has($name)) {
-            throw new \InvalidArgumentException(sprintf(
-                'Unknown helper: "%s"',
-                var_export($name, true)
-            ));
+            throw new \InvalidArgumentException(
+                sprintf(
+                    'Unknown helper: "%s"',
+                    var_export($name, true)
+                )
+            );
         }
 
         if ($this->helpers[$name] instanceof Helper) {
@@ -175,10 +179,12 @@ class Helpers
     public function __get($name)
     {
         if (!$this->has($name)) {
-            throw new \InvalidArgumentException(sprintf(
-                'Unknown helper: "%s"',
-                var_export($name, true)
-            ));
+            throw new \InvalidArgumentException(
+                sprintf(
+                    'Unknown helper: "%s"',
+                    var_export($name, true)
+                )
+            );
         }
 
         return $this->helpers[$name];
@@ -233,10 +239,12 @@ class Helpers
     public function remove($name)
     {
         if (!$this->has($name)) {
-            throw new \InvalidArgumentException(sprintf(
-                'Unknown helper: "%s"',
-                var_export($name, true)
-            ));
+            throw new \InvalidArgumentException(
+                sprintf(
+                    'Unknown helper: "%s"',
+                    var_export($name, true)
+                )
+            );
         }
 
         unset($this->helpers[$name]);

--- a/src/Handlebars/Helpers.php
+++ b/src/Handlebars/Helpers.php
@@ -101,7 +101,7 @@ class Helpers
         if (!is_callable($helper) && ! $helper instanceof Helper) {
             throw new \InvalidArgumentException(sprintf(
                 "%s Helper is not a callable or doesn't implement the Helper interface.",
-                $name
+                var_export($name, true)
             ));
         }
         $this->helpers[$name] = $helper;
@@ -139,7 +139,7 @@ class Helpers
         if (!$this->has($name)) {
             throw new \InvalidArgumentException(sprintf(
                 'Unknown helper: "%s"',
-                $name
+                var_export($name, true)
             ));
         }
 
@@ -177,7 +177,7 @@ class Helpers
         if (!$this->has($name)) {
             throw new \InvalidArgumentException(sprintf(
                 'Unknown helper: "%s"',
-                $name
+                var_export($name, true)
             ));
         }
 
@@ -235,7 +235,7 @@ class Helpers
         if (!$this->has($name)) {
             throw new \InvalidArgumentException(sprintf(
                 'Unknown helper: "%s"',
-                $name
+                var_export($name, true)
             ));
         }
 

--- a/src/Handlebars/Helpers.php
+++ b/src/Handlebars/Helpers.php
@@ -102,7 +102,7 @@ class Helpers
             throw new \InvalidArgumentException(
                 sprintf(
                     "%s Helper is not a callable or doesn't implement the Helper interface.",
-                    var_export($name, true)
+                    $name
                 )
             );
         }
@@ -142,7 +142,7 @@ class Helpers
             throw new \InvalidArgumentException(
                 sprintf(
                     'Unknown helper: "%s"',
-                    var_export($name, true)
+                    $name
                 )
             );
         }
@@ -182,7 +182,7 @@ class Helpers
             throw new \InvalidArgumentException(
                 sprintf(
                     'Unknown helper: "%s"',
-                    var_export($name, true)
+                    $name
                 )
             );
         }
@@ -242,7 +242,7 @@ class Helpers
             throw new \InvalidArgumentException(
                 sprintf(
                     'Unknown helper: "%s"',
-                    var_export($name, true)
+                    $name
                 )
             );
         }

--- a/src/Handlebars/Loader/InlineLoader.php
+++ b/src/Handlebars/Loader/InlineLoader.php
@@ -75,17 +75,21 @@ class InlineLoader implements Loader
     public function __construct($fileName, $offset)
     {
         if (!is_file($fileName)) {
-            throw new \InvalidArgumentException(sprintf(
-                'InlineLoader expects a valid filename, "%s" given.',
-                $fileName
-            ));
+            throw new \InvalidArgumentException(
+                sprintf(
+                    'InlineLoader expects a valid filename, "%s" given.',
+                    $fileName
+                )
+            );
         }
 
         if (!is_int($offset) || $offset < 0) {
-            throw new \InvalidArgumentException(sprintf(
-                'InlineLoader expects a valid file offset, "%s" given.',
-                $offset
-            ));
+            throw new \InvalidArgumentException(
+                sprintf(
+                    'InlineLoader expects a valid file offset, "%s" given.',
+                    $offset
+                )
+            );
         }
 
         $this->fileName = $fileName;

--- a/src/Handlebars/Loader/InlineLoader.php
+++ b/src/Handlebars/Loader/InlineLoader.php
@@ -75,11 +75,17 @@ class InlineLoader implements Loader
     public function __construct($fileName, $offset)
     {
         if (!is_file($fileName)) {
-            throw new \InvalidArgumentException('InlineLoader expects a valid filename.');
+            throw new \InvalidArgumentException(sprintf(
+                'InlineLoader expects a valid filename, "%s" given.',
+                $fileName
+            ));
         }
 
         if (!is_int($offset) || $offset < 0) {
-            throw new \InvalidArgumentException('InlineLoader expects a valid file offset.');
+            throw new \InvalidArgumentException(sprintf(
+                'InlineLoader expects a valid file offset, "%s" given.',
+                $offset
+            ));
         }
 
         $this->fileName = $fileName;
@@ -98,7 +104,7 @@ class InlineLoader implements Loader
         $this->loadTemplates();
 
         if (!array_key_exists($name, $this->templates)) {
-            throw new \InvalidArgumentException("Template {$name} not found.");
+            throw new \InvalidArgumentException("Template $name not found.");
         }
 
         return $this->templates[$name];

--- a/src/Handlebars/Parser.php
+++ b/src/Handlebars/Parser.php
@@ -78,9 +78,10 @@ class Parser
                     do {
                         $result = array_pop($stack);
                         if ($result === null) {
-                            throw new \LogicException(
-                                'Unexpected closing tag: /' . $token[Tokenizer::NAME]
-                            );
+                            throw new \LogicException(sprintf(
+                                'Unexpected closing tag: /%s',
+                                $token[Tokenizer::NAME]
+                            ));
                         }
 
                         if (!array_key_exists(Tokenizer::NODES, $result)

--- a/src/Handlebars/Parser.php
+++ b/src/Handlebars/Parser.php
@@ -81,7 +81,7 @@ class Parser
                             throw new \LogicException(
                                 sprintf(
                                     'Unexpected closing tag: /%s',
-                                    var_export($token[Tokenizer::NAME], true)
+                                    $token[Tokenizer::NAME]
                                 )
                             );
                         }

--- a/src/Handlebars/Parser.php
+++ b/src/Handlebars/Parser.php
@@ -78,10 +78,12 @@ class Parser
                     do {
                         $result = array_pop($stack);
                         if ($result === null) {
-                            throw new \LogicException(sprintf(
-                                'Unexpected closing tag: /%s',
-                                var_export($token[Tokenizer::NAME], true)
-                            ));
+                            throw new \LogicException(
+                                sprintf(
+                                    'Unexpected closing tag: /%s',
+                                    var_export($token[Tokenizer::NAME], true)
+                                )
+                            );
                         }
 
                         if (!array_key_exists(Tokenizer::NODES, $result)

--- a/src/Handlebars/Parser.php
+++ b/src/Handlebars/Parser.php
@@ -80,7 +80,7 @@ class Parser
                         if ($result === null) {
                             throw new \LogicException(sprintf(
                                 'Unexpected closing tag: /%s',
-                                $token[Tokenizer::NAME]
+                                var_export($token[Tokenizer::NAME], true)
                             ));
                         }
 

--- a/src/Handlebars/Template.php
+++ b/src/Handlebars/Template.php
@@ -30,7 +30,7 @@ namespace Handlebars;
  *
  * @category  Xamin
  * @package   Handlebars
- * @author    fzerorubigd <fzerorubigd@gmail.com>
+ * @author    fzerorubigd <fzerorubigd@gmail.com>, Pascal Thormeier <pascal.thormeier@gmail.com>
  * @copyright 2010-2012 (c) Justin Hileman
  * @copyright 2012 (c) ParsPooyesh Co
  * @license   MIT <http://opensource.org/licenses/MIT>
@@ -502,7 +502,19 @@ class Template
         $partial = $this->handlebars->loadPartial($current[Tokenizer::NAME]);
 
         if ($current[Tokenizer::ARGS]) {
-            $context = $context->get($current[Tokenizer::ARGS]);
+            preg_match_all(
+                '/(\w+\=["|\'][^"\']+["|\']|\w+\=[a-zA-Z0-9\.\=]+)+/m',
+                $current[Tokenizer::ARGS],
+                $args
+            );
+
+            $partialArgs = array();
+            foreach ($args[0] as $arg) {
+                list($key, $value) = explode('=', $arg, 2);
+                $partialArgs[$key] = strpos($value, '"') === false ? $context->get($value) : trim('"', $value);
+            }
+
+            $context = new Context($partialArgs);
         }
 
         return $partial->render($context);

--- a/src/Handlebars/Template.php
+++ b/src/Handlebars/Template.php
@@ -404,9 +404,10 @@ class Template
         try {
             $sectionVar = $context->get($sectionName, true);
         } catch (\InvalidArgumentException $e) {
-            throw new \RuntimeException(
-                $sectionName . ' is not registered as a helper'
-            );
+            throw new \RuntimeException(sprintf(
+                '"%s" is not registered as a helper',
+                $sectionName
+            ));
         }
         $buffer = '';
         if (is_array($sectionVar) || $sectionVar instanceof \Traversable) {
@@ -461,9 +462,10 @@ class Template
         } elseif (trim($current[Tokenizer::ARGS]) == '') {
             return $this->_mustacheStyleSection($context, $current);
         } else {
-            throw new \RuntimeException(
-                $sectionName . ' is not registered as a helper'
-            );
+            throw new \RuntimeException(sprintf(
+                '"%s"" is not registered as a helper',
+                $sectionName
+            ));
         }
     }
 

--- a/src/Handlebars/Template.php
+++ b/src/Handlebars/Template.php
@@ -409,7 +409,7 @@ class Template
             throw new \RuntimeException(
                 sprintf(
                     '"%s" is not registered as a helper',
-                    var_export($sectionName, true)
+                    $sectionName
                 )
             );
         }
@@ -469,7 +469,7 @@ class Template
             throw new \RuntimeException(
                 sprintf(
                     '"%s"" is not registered as a helper',
-                    var_export($sectionName, true)
+                    $sectionName
                 )
             );
         }

--- a/src/Handlebars/Template.php
+++ b/src/Handlebars/Template.php
@@ -30,7 +30,8 @@ namespace Handlebars;
  *
  * @category  Xamin
  * @package   Handlebars
- * @author    fzerorubigd <fzerorubigd@gmail.com>, Pascal Thormeier <pascal.thormeier@gmail.com>
+ * @author    fzerorubigd <fzerorubigd@gmail.com>
+ * @author    Pascal Thormeier <pascal.thormeier@gmail.com>
  * @copyright 2010-2012 (c) Justin Hileman
  * @copyright 2012 (c) ParsPooyesh Co
  * @license   MIT <http://opensource.org/licenses/MIT>
@@ -404,10 +405,12 @@ class Template
         try {
             $sectionVar = $context->get($sectionName, true);
         } catch (\InvalidArgumentException $e) {
-            throw new \RuntimeException(sprintf(
-                '"%s" is not registered as a helper',
-                var_export($sectionName, true)
-            ));
+            throw new \RuntimeException(
+                sprintf(
+                    '"%s" is not registered as a helper',
+                    var_export($sectionName, true)
+                )
+            );
         }
         $buffer = '';
         if (is_array($sectionVar) || $sectionVar instanceof \Traversable) {
@@ -462,10 +465,12 @@ class Template
         } elseif (trim($current[Tokenizer::ARGS]) == '') {
             return $this->_mustacheStyleSection($context, $current);
         } else {
-            throw new \RuntimeException(sprintf(
-                '"%s"" is not registered as a helper',
-                var_export($sectionName, true)
-            ));
+            throw new \RuntimeException(
+                sprintf(
+                    '"%s"" is not registered as a helper',
+                    var_export($sectionName, true)
+                )
+            );
         }
     }
 
@@ -508,7 +513,7 @@ class Template
                 $args
             );
 
-            $context = new Context($this->_getPartialArguments($context, $args[0]));
+            $context = new Context($this->_getPartialArgumentsValues($context, $args[0]));
         }
 
         return $partial->render($context);
@@ -517,12 +522,12 @@ class Template
     /**
      * Prepare the arguments of a partial to actual array values to be used in a new context
      *
-     * @param Context $context
-     * @param array   $args
+     * @param Context $context Current context
+     * @param array   $args    Arguments given by tokenizer, splitted to key=>value pairs
      *
      * @return array
      */
-    private function _getPartialArguments(Context $context, array $args)
+    private function _getPartialArgumentsValues(Context $context, array $args)
     {
         $partialArgs = array();
 

--- a/tests/Xamin/HandlebarsTest.php
+++ b/tests/Xamin/HandlebarsTest.php
@@ -176,7 +176,7 @@ class HandlebarsTest extends \PHPUnit_Framework_TestCase
                 '{{#if first}}The first{{else}}{{#if second}}The second{{/if}}{{/if}}',
                 array('first' => false, 'second' => true),
                 'The second'
-            )
+            ),
         );
     }
 

--- a/tests/Xamin/HandlebarsTest.php
+++ b/tests/Xamin/HandlebarsTest.php
@@ -715,7 +715,11 @@ EOM;
     public function testPartial()
     {
         $loader = new \Handlebars\Loader\StringLoader();
-        $partialLoader = new \Handlebars\Loader\ArrayLoader(array('test' => '{{key}}', 'bar' => 'its foo'));
+        $partialLoader = new \Handlebars\Loader\ArrayLoader(array(
+            'test' => '{{key}}',
+            'bar' => 'its foo',
+            'presetVariables' => '{{myVar}}',
+        ));
         $partialAliasses = array('foo' => 'bar');
         $engine = new \Handlebars\Handlebars(
             array(
@@ -733,6 +737,9 @@ EOM;
 
         $this->setExpectedException('RuntimeException');
         $engine->render('{{>foo-again}}', array());
+
+        $this->assertEquals('foobar', $engine->render("{{>presetVariables myVar='foobar'}}", array()));
+        $this->assertEquals('foobar=barbaz', $engine->render("{{>presetVariables myVar='foobar=barbaz'}}", array()));
     }
 
     /**


### PR DESCRIPTION
This PR solves two issues:

1) **Improving of error reporting**: Exception messages are now a little more verbose on what's actually wrong and where. For instance, a simple "Can not find variable" in logs doesn't really help if you don't know the name of the variable.

2) **Support of arguments for partials**: Partial rendering was throwing exceptions when passing multiple arguments and hardcoded strings. See http://handlebarsjs.com/partials.html for supported cases.