### PR TITLE
Fix handling of named arguments in partials

### DIFF
--- a/src/Handlebars/Template.php
+++ b/src/Handlebars/Template.php
@@ -540,11 +540,7 @@ class Template
 
         $namedArguments = array();
         foreach ($arguments->getNamedArguments() as $key => $value) {
-            if (false === $value instanceof String) {
-                $value = $context->get($value);
-            }
-
-            $namedArguments[$key] = $value;
+            $namedArguments[$key] = $context->get($value);
         }
 
         return array_merge($positionalArgs, $namedArguments);

--- a/src/Handlebars/Template.php
+++ b/src/Handlebars/Template.php
@@ -538,7 +538,16 @@ class Template
             }
         }
 
-        return array_merge($positionalArgs, $arguments->getNamedArguments());
+        $namedArguments = array();
+        foreach ($arguments->getNamedArguments() as $key => $value) {
+            if (false === $value instanceof String) {
+                $value = $context->get($value);
+            }
+
+            $namedArguments[$key] = $value;
+        }
+
+        return array_merge($positionalArgs, $namedArguments);
     }
 
 

--- a/tests/Xamin/HandlebarsTest.php
+++ b/tests/Xamin/HandlebarsTest.php
@@ -729,6 +729,11 @@ EOM;
             )
         );
 
+        $this->assertEquals('foobar', $engine->render("{{>presetVariables myVar='foobar'}}", array()));
+        $this->assertEquals('foobar=barbaz', $engine->render("{{>presetVariables myVar='foobar=barbaz'}}", array()));
+        $this->assertEquals('qux', $engine->render("{{>presetVariables myVar=foo}}", array('foo' => 'qux')));
+        $this->assertEquals('qux', $engine->render("{{>presetVariables myVar=foo.bar}}", array('foo' => array('bar' => 'qux'))));
+
         $this->assertEquals('HELLO', $engine->render('{{>test parameter}}', array('parameter' => array('key' => 'HELLO'))));
         $this->assertEquals('its foo', $engine->render('{{>foo}}', array()));
         $engine->registerPartial('foo-again', 'bar');
@@ -737,9 +742,6 @@ EOM;
 
         $this->setExpectedException('RuntimeException');
         $engine->render('{{>foo-again}}', array());
-
-        $this->assertEquals('foobar', $engine->render("{{>presetVariables myVar='foobar'}}", array()));
-        $this->assertEquals('foobar=barbaz', $engine->render("{{>presetVariables myVar='foobar=barbaz'}}", array()));
     }
 
     /**


### PR DESCRIPTION
Also fix tests that weren't even executed.

Now constructs like `{{> partial foo=bar.baz }}` are also possible.