### PR TITLE
Fix handling of @root helper arguments

### DIFF
--- a/src/Handlebars/Arguments.php
+++ b/src/Handlebars/Arguments.php
@@ -109,7 +109,7 @@ class Arguments
         $bad_chars = preg_quote(Context::NOT_VALID_NAME_CHARS, '#');
         $bad_seg_chars = preg_quote(Context::NOT_VALID_SEGMENT_NAME_CHARS, '#');
 
-        $name_chunk = '(?:[^' . $bad_chars . '\s]+)|(?:\[[^' . $bad_seg_chars . ']+\])';
+        $name_chunk = '(?:@?[^' . $bad_chars . '\s]+)|(?:\[[^' . $bad_seg_chars . ']+\])';
         $variable_name = '(?:\.\.\/)*(?:(?:' . $name_chunk . ')[\.\/])*(?:' . $name_chunk  . ')\.?';
         $special_variable_name = '@[a-z]+';
         $escaped_value = '(?:(?<!\\\\)".*?(?<!\\\\)"|(?<!\\\\)\'.*?(?<!\\\\)\')';

--- a/tests/Xamin/HandlebarsTest.php
+++ b/tests/Xamin/HandlebarsTest.php
@@ -1251,6 +1251,7 @@ EOM;
         return array(
             array('{{foo}} {{ @root.foo }}', array( 'foo' => 'bar' ), "bar bar"),
             array('{{@root.foo}} {{#each arr}}{{ @root.foo }}{{/each}}', array( 'foo' => 'bar', 'arr' => array( '1' ) ), "bar bar"),
+            array('{{add @root.one @root.two}}', array( 'one' => '1', 'two' => '2' ), "3"),
         );
     }
 
@@ -1268,6 +1269,15 @@ EOM;
     public function testRootSpecialVariableHelpers($template, $data, $results)
     {
         $engine = new \Handlebars\Handlebars();
+        $engine->addHelper('add', function ($template, $context, $args) {
+            $sum = 0;
+
+            foreach ($template->parseArguments($args) as $value) {
+                $sum += intval($context->get($value));
+            }
+
+            return $sum;
+        });
 
         $res = $engine->render($template, $data);
         $this->assertEquals($res, $results);


### PR DESCRIPTION
I've noticed that using helper arguments in @root... notation causes an error. 

This is an attempt to fix it by simply allowing '@' as first char in the $name_chunks regexp in Arguments->parse().

What do you think?