### PR TITLE
PHP7 String keyword

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ php:
   - 5.4
   - 5.5
   - 5.6
+  - 7.0
   - hhvm
 branches:
   except:

--- a/src/Handlebars/Arguments.php
+++ b/src/Handlebars/Arguments.php
@@ -155,26 +155,26 @@ class Arguments
     /**
      * Prepares argument's value to add to arguments list.
      *
-     * The method unescapes value and wrap it into \Handlebars\String class if
-     * needed.
+     * The method unescapes value and wrap it into \Handlebars\StringWrapper
+     * class if needed.
      *
      * @param string $value Argument's value
      *
-     * @return string|\Handlebars\String
+     * @return string|\Handlebars\StringWrapper
      */
     protected function prepareArgumentValue($value)
     {
         // Check if argument's value is a quoted string literal
         if ($value[0] == "'" || $value[0] == '"') {
             // Remove enclosing quotes and unescape
-            return new String(stripcslashes(substr($value, 1, -1)));
+            return new StringWrapper(stripcslashes(substr($value, 1, -1)));
         }
 
         // Check if the value is an integer literal
         if (preg_match("/^-?\d+$/", $value)) {
             // Wrap the value into the String class to tell the Context that
             // it's a value and not a variable name.
-            return new String($value);
+            return new StringWrapper($value);
         }
 
         return $value;

--- a/src/Handlebars/Context.php
+++ b/src/Handlebars/Context.php
@@ -185,7 +185,7 @@ class Context
      */
     public function get($variableName, $strict = false)
     {
-        if ($variableName instanceof \Handlebars\String) {
+        if ($variableName instanceof \Handlebars\StringWrapper) {
             return (string)$variableName;
         }
         $variableName = trim($variableName);

--- a/src/Handlebars/Loader/FilesystemLoader.php
+++ b/src/Handlebars/Loader/FilesystemLoader.php
@@ -24,7 +24,7 @@
 namespace Handlebars\Loader;
 
 use Handlebars\Loader;
-use Handlebars\String;
+use Handlebars\StringWrapper;
 
 /**
  * Handlebars Template filesystem Loader implementation.
@@ -76,7 +76,7 @@ class FilesystemLoader implements Loader
      *
      * @param string $name template name
      *
-     * @return String Handlebars Template source
+     * @return StringWrapper Handlebars Template source
      */
     public function load($name)
     {
@@ -84,7 +84,7 @@ class FilesystemLoader implements Loader
             $this->_templates[$name] = $this->loadFile($name);
         }
 
-        return new String($this->_templates[$name]);
+        return new StringWrapper($this->_templates[$name]);
     }
 
     /**

--- a/src/Handlebars/Loader/StringLoader.php
+++ b/src/Handlebars/Loader/StringLoader.php
@@ -19,7 +19,7 @@
 
 namespace Handlebars\Loader;
 use Handlebars\Loader;
-use Handlebars\String;
+use Handlebars\StringWrapper;
 
 /**
  * Handlebars Template string Loader implementation.
@@ -42,11 +42,11 @@ class StringLoader implements Loader
      *
      * @param string $name Handlebars Template source
      *
-     * @return String Handlebars Template source
+     * @return StringWrapper Handlebars Template source
      */
     public function load($name)
     {
-        return new String($name);
+        return new StringWrapper($name);
     }
 
 }

--- a/src/Handlebars/StringWrapper.php
+++ b/src/Handlebars/StringWrapper.php
@@ -20,16 +20,15 @@ namespace Handlebars;
 /**
  * Handlebars string
  *
- * @category   Xamin
- * @package    Handlebars
- * @author     fzerorubigd <fzerorubigd@gmail.com>
- * @copyright  2013 Authors
- * @license    MIT <http://opensource.org/licenses/MIT>
- * @version    Release: @package_version@
- * @link       http://xamin.ir
- * @deprecated Since v0.10.3. Use \Handlebars\StringWrapper instead.
+ * @category  Xamin
+ * @package   Handlebars
+ * @author    fzerorubigd <fzerorubigd@gmail.com>
+ * @copyright 2013 Authors
+ * @license   MIT <http://opensource.org/licenses/MIT>
+ * @version   Release: @package_version@
+ * @link      http://xamin.ir
  */
 
-class String extends StringWrapper
+class StringWrapper extends BaseString
 {
 }

--- a/src/Handlebars/Template.php
+++ b/src/Handlebars/Template.php
@@ -381,7 +381,7 @@ class Template
 
         $return = $helpers->call($sectionName, $this, $context, $current[Tokenizer::ARGS], $source);
 
-        if ($return instanceof String) {
+        if ($return instanceof StringWrapper) {
             return $this->handlebars->loadString($return)->render($context);
         } else {
             return $return;

--- a/src/Handlebars/Tokenizer.php
+++ b/src/Handlebars/Tokenizer.php
@@ -122,7 +122,7 @@ class Tokenizer
      */
     public function scan($text/*, $delimiters = null*/)
     {
-        if ($text instanceof String) {
+        if ($text instanceof StringWrapper) {
             $text = $text->getString();
         }
         $this->reset();

--- a/tests/Xamin/HandlebarsTest.php
+++ b/tests/Xamin/HandlebarsTest.php
@@ -395,7 +395,7 @@ class HandlebarsTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('Test helper is called with a b c', $engine->render('{{test2 a b c}}', array()));
 
         $engine->addHelper('renderme', function () {
-            return new \Handlebars\String("{{test}}");
+            return new \Handlebars\StringWrapper("{{test}}");
         });
         $this->assertEquals('Test helper is called', $engine->render('{{#renderme}}', array()));
 
@@ -568,9 +568,9 @@ class HandlebarsTest extends \PHPUnit_Framework_TestCase
     /**
      * test String class
      */
-    public function testStringClass()
+    public function testStringWrapperClass()
     {
-        $string = new \Handlebars\String('test');
+        $string = new \Handlebars\StringWrapper('test');
         $this->assertEquals('test', $string->getString());
         $string->setString('new');
         $this->assertEquals('new', $string->getString());
@@ -1096,7 +1096,7 @@ EOM;
 
     public function testString()
     {
-        $string = new \Handlebars\String("Hello World");
+        $string = new \Handlebars\StringWrapper("Hello World");
         $this->assertEquals((string)$string, "Hello World");
     }
 


### PR DESCRIPTION
This PR is attended to fix #133.

To keep backward compatibility I've just replaced `\Handlebars\String` with `\Handlebars\StringWrapper`. Nevertheless, we have to redesign all string wrappers (to simplify them) when the backward compatibility can be broken.