### PR TITLE
Updates if and unless helper behavior for handlebars 4

### DIFF
--- a/src/Handlebars/Helper/IfHelper.php
+++ b/src/Handlebars/Helper/IfHelper.php
@@ -53,7 +53,6 @@ class IfHelper implements Helper
         $parsedArgs = $template->parseArguments($args);
         $tmp = $context->get($parsedArgs[0]);
 
-        $context->push($context->last());
         if ($tmp) {
             $template->setStopToken('else');
             $buffer = $template->render($context);
@@ -65,7 +64,6 @@ class IfHelper implements Helper
             $template->setStopToken(false);
             $buffer = $template->render($context);
         }
-        $context->pop();
 
         return $buffer;
     }

--- a/src/Handlebars/Helper/UnlessHelper.php
+++ b/src/Handlebars/Helper/UnlessHelper.php
@@ -53,8 +53,6 @@ class UnlessHelper implements Helper
         $parsedArgs = $template->parseArguments($args);
         $tmp = $context->get($parsedArgs[0]);
 
-        $context->push($context->last());
-
         if (!$tmp) {
             $template->setStopToken('else');
             $buffer = $template->render($context);
@@ -65,8 +63,6 @@ class UnlessHelper implements Helper
             $template->setStopToken(false);
             $buffer = $template->render($context);
         }
-
-        $context->pop();
 
         return $buffer;
     }

--- a/tests/Xamin/HandlebarsTest.php
+++ b/tests/Xamin/HandlebarsTest.php
@@ -1174,16 +1174,34 @@ EOM;
         $this->assertEquals('A-B', $engine->render('{{concat (concat a "-") b}}', array('a' => 'A', 'b' => 'B', 'A-' => '!')));
     }
 
+    public function ifUnlessDepthDoesntChangeProvider()
+    {
+        return [[
+            '{{#with b}}{{#if this}}{{../a}}{{/if}}{{/with}}',
+            ['a' => 'good', 'b' => 'stump'],
+            'good',
+        ], [
+            '{{#with b}}{{#unless false}}{{../a}}{{/unless}}{{/with}}',
+            ['a' => 'good', 'b' => 'stump'],
+            'good',
+        ], [
+            '{{#with foo}}{{#if goodbye}}GOODBYE cruel {{../world}}!{{/if}}{{/with}}',
+            ['foo' => ['goodbye' => true], 'world' => 'world'],
+            'GOODBYE cruel world!',
+        ]];
+    }
+
     /**
-     * Test if and unless adding an extra layer when accessing parent
+     * Test if and unless do not add an extra layer when accessing parent
+     *
+     * @dataProvider ifUnlessDepthDoesntChangeProvider
      */
-    public function testIfUnlessExtraLayer()
+    public function testIfUnlessDepthDoesntChange($template, $data, $expected)
     {
         $loader = new \Handlebars\Loader\StringLoader();
         $engine = new \Handlebars\Handlebars(array('loader' => $loader));
 
-        $this->assertEquals('good', $engine->render('{{#with b}}{{#if this}}{{../../a}}{{/if}}{{/with}}', array('a' => 'good', 'b' => 'stump')));
-        $this->assertEquals('good', $engine->render('{{#with b}}{{#unless false}}{{../../a}}{{/unless}}{{/with}}', array('a' => 'good', 'b' => 'stump')));
+        $this->assertEquals($expected, $engine->render($template, $data));
     }
 
     /**


### PR DESCRIPTION
handlebars.js 4.0.0 changed the depth behaviour when using the if and
unless conditionals - https://github.com/wycats/handlebars.js/issues/1028

The context depth is no longer altered by the `{{#if}}` and `{{#unless}}` conditionals.

This commit changes the handlebars.php helpers to match.