### PR TITLE
Add failing test for Mustache-style `if` blocks

### DIFF
--- a/src/Handlebars/Parser.php
+++ b/src/Handlebars/Parser.php
@@ -87,6 +87,8 @@ class Parser
 
                         if (!array_key_exists(Tokenizer::NODES, $result)
                             && isset($result[Tokenizer::NAME])
+                            && ($result[Tokenizer::TYPE] == Tokenizer::T_SECTION
+                            || $result[Tokenizer::TYPE] == Tokenizer::T_INVERTED)
                             && $result[Tokenizer::NAME] == $token[Tokenizer::NAME]
                         ) {
                             if (isset($result[Tokenizer::TRIM_RIGHT]) 

--- a/tests/Xamin/HandlebarsTest.php
+++ b/tests/Xamin/HandlebarsTest.php
@@ -177,6 +177,11 @@ class HandlebarsTest extends \PHPUnit_Framework_TestCase
                 array('first' => false, 'second' => true),
                 'The second'
             ),
+            array(
+                '{{#value}}Hello {{value}}, from {{parent_context}}{{/value}}',
+                array('value' => 'string', 'parent_context' => 'parent string'),
+                'Hello string, from parent string'
+            ),
         );
     }
 


### PR DESCRIPTION
Would fix #162, if it will pass. Opening this PR for feedback, because the output is quite broken. Using the variable for the `#variable` conditional, and then using it again in the block, appears to terminate the block. Any thoughts as to why this happens/where to look?