### PR TITLE
Fix #174 PHP 7.3 continue warning

### DIFF
--- a/src/Handlebars/Tokenizer.php
+++ b/src/Handlebars/Tokenizer.php
@@ -164,7 +164,7 @@ class Tokenizer
                 } elseif ($this->tagChange(self::T_UNESCAPED.$this->otag, $text, $i) and $this->escaped) {
                     $this->buffer .= "{{{";
                     $i += 2;
-                    continue;
+                    break;
                 } elseif ($this->tagChange($this->otag, $text, $i) and (!$this->escaped || $prev_slash)) {
                     $i--;
                     $this->flushBuffer();
@@ -210,7 +210,7 @@ class Tokenizer
             default:
                 if ($this->tagChange(self::T_TRIM . $this->ctag, $text, $i)) {
                     $this->trimRight = true;
-                    continue;
+                    break;
                 }
                 if ($this->tagChange($this->ctag, $text, $i)) {
                     // Sections (Helpers) can accept parameters


### PR DESCRIPTION
Replace continue with break inside switch statements.
There are no test updates because the tests already fail for PHP 7.3 before this fix.